### PR TITLE
Remove the `-a` argument

### DIFF
--- a/perf/readme.md
+++ b/perf/readme.md
@@ -35,7 +35,7 @@ docker top <containername>
 
 ## Measure
 ```
-perf record -a -g -F 97 -p <PID>
+perf record -g -F 97 -p <PID>
 ```
 
 ## Analyze results


### PR DESCRIPTION
`-a` (all CPUs) argument is overridden by the `-p` (PID) argument and thus has no effect.